### PR TITLE
OpenSSL 3.0, SIGPIPE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ compile
 config.guess
 config.sub
 configure
+configure~
 depcomp
 install-sh
 ltmain.sh

--- a/src/dumdohd.c
+++ b/src/dumdohd.c
@@ -107,7 +107,6 @@ static int alpn_select_proto_cb(SSL* ssl, const unsigned char** out,
 static SSL_CTX* create_ssl_ctx(const char* key_file, const char* cert_file)
 {
     SSL_CTX* ssl_ctx;
-    EC_KEY*  ecdh;
 
     ssl_ctx = SSL_CTX_new(SSLv23_server_method());
     if (!ssl_ctx) {
@@ -116,14 +115,6 @@ static SSL_CTX* create_ssl_ctx(const char* key_file, const char* cert_file)
     }
     SSL_CTX_set_options(ssl_ctx,
         SSL_OP_ALL | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION | SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
-
-    ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
-    if (!ecdh) {
-        errx(1, "EC_KEY_new_by_curv_name failed: %s",
-            ERR_error_string(ERR_get_error(), NULL));
-    }
-    SSL_CTX_set_tmp_ecdh(ssl_ctx, ecdh);
-    EC_KEY_free(ecdh);
 
     if (SSL_CTX_use_PrivateKey_file(ssl_ctx, key_file, SSL_FILETYPE_PEM) != 1) {
         errx(1, "Could not read private key file %s", key_file);

--- a/src/dumdumd.c
+++ b/src/dumdumd.c
@@ -30,6 +30,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <stdbool.h>
+#include <signal.h>
 
 #undef ANYBACKEND
 
@@ -1053,6 +1054,11 @@ int main(int argc, char* argv[])
     }
 
     freeaddrinfo(addrinfo);
+
+    struct sigaction act;
+    memset(&act, 0, sizeof(struct sigaction));
+    act.sa_handler = SIG_IGN;
+    sigaction(SIGPIPE, &act, NULL);
 
 #ifdef HAVE_LIBEV
     if (use_ev) {


### PR DESCRIPTION
- `dumdohd`: Remove deprecated OpenSSL functions
- `dumdumd`: Ignore SIGPIPE, can happen during `BIO_write()`