### PR TITLE
Dockerfile update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,5 @@ src/stamp-h1
 build
 
 # Project specific files
+src/dumdohd
 src/dumdumd

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN apt-get install -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 build-essential libev-dev libuv1-dev libssl-dev autoconf automake autotools-dev libtool pkg-config
+RUN apt-get install -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 build-essential libev-dev libuv1-dev libssl-dev autoconf automake autotools-dev libtool pkg-config libnghttp2-dev libevent-dev
 
 COPY . /dumdumd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,47 @@
-FROM ubuntu:20.04
+ARG BASE_IMAGE=ubuntu:23.10
+FROM $BASE_IMAGE AS runtime_base
+MAINTAINER Petr Spacek <pspacek@isc.org>
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 build-essential libev-dev libuv1-dev libssl-dev autoconf automake autotools-dev libtool pkg-config libnghttp2-dev libevent-dev
+RUN apt-get upgrade -y -qqq
 
+# runtime depedencies
+RUN apt-get install -y -qqq -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 \
+	libev4 \
+	libevent-2.1 \
+	libevent-openssl-2.1 \
+	libnghttp2-14 \
+	libssl3 \
+	libssl3 \
+	libuv1
+
+# separate image for build, will not be tagged at the end
+FROM runtime_base AS build_stage
+RUN apt-get install -y -qqq -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 \
+	autoconf \
+	automake \
+	build-essential \
+	git \
+	libev-dev \
+	libevent-dev \
+	libnghttp2-dev \
+	libssl-dev \
+	libtool \
+	libuv1-dev \
+	pkg-config
+
+# copy repo as build context
 COPY . /dumdumd
-
 WORKDIR /dumdumd
 RUN ./autogen.sh
-RUN ./configure
-RUN make
+RUN ./configure --prefix=/usr/local
+RUN make -j$(nproc)
 RUN make install
+RUN git log -1 > /usr/local/dumdumd.git.log
+RUN git diff > /usr/local/dumdumd.git.diff
+RUN git status > /usr/local/dumdumd.git.status
 
-ENTRYPOINT ["dumdumd"]
+# copy only installed artifacts and throw away everything else
+FROM runtime_base AS installed
+COPY --from=build_stage /usr/local /usr/local


### PR DESCRIPTION
- dumdohd libraries were missing
- Dockerfile is now split between build and runtime phases to cut down resulting image size